### PR TITLE
add src/{main,test}/resources dirs to structure

### DIFF
--- a/contents/index.adoc
+++ b/contents/index.adoc
@@ -64,13 +64,15 @@ The `init` task runs the `wrapper` task first, which generates the `gradlew` and
 ├── settings.gradle
 └── src
     ├── main
-    │   └── java  // <2>
-    │       └── demo
-    │           └── App.java
+    │   ├── java  // <2>
+    │   │   └── demo
+    │   │       └── App.java
+    │   └── resources
     └── test      // <3>
-        └── java
-            └── demo
-                └── AppTest.java
+        ├── java
+        │   └── demo
+        │       └── AppTest.java
+        └── resources
 ----
 
 [source.multi-language-sample,kotlin]
@@ -85,13 +87,15 @@ The `init` task runs the `wrapper` task first, which generates the `gradlew` and
 ├── settings.gradle.kts
 └── src
     ├── main
-    │   └── java  // <2>
-    │       └── demo
-    │           └── App.java
+    │   ├── java  // <2>
+    │   │   └── demo
+    │   │       └── App.java
+    │   └── resources
     └── test      // <3>
-        └── java
-            └── demo
-                └── AppTest.java
+        ├── java
+        │   └── demo
+        │       └── AppTest.java
+        └── resources
 ----
 <1> Generated folder for wrapper files
 <2> Default Java source folder


### PR DESCRIPTION
In Gradle 5.3.1, `gradle init --type java-application` also generates the empty directories
- `src/main/resources`
- `src/test/resources`